### PR TITLE
fixing list styling for the post content

### DIFF
--- a/src/components/BlogPost/styles.js
+++ b/src/components/BlogPost/styles.js
@@ -6,6 +6,13 @@ const style =  (Component) => styled(Component)`
     margin-left: auto;
     margin-right: auto;
 
+    ol,ul{
+        list-style:disc;
+        padding-left:40px
+        margin-top:20px;
+        margin-bottom:20px;
+    }
+
     .btn-inverse{
         min-height:50px;
         padding: 5px;


### PR DESCRIPTION
## Motivation

Our client contacted us saying that the lists aren't properly showing. This minor fix removes the error 🥇 

## Proposed solution

The commons.css file was interfering with the css of the post content
![image](https://user-images.githubusercontent.com/48529975/127709440-f650d44e-1966-4315-9d5f-49ba2d3377c1.png)
Added custom css for lists at 3d431f6


### Before
![image](https://user-images.githubusercontent.com/48529975/127709494-2d06cac1-e373-449c-8c66-c249eb15681f.png)


### After
![image](https://user-images.githubusercontent.com/48529975/127709501-77f10a3a-241f-484d-abdc-bf1038c45f51.png)
